### PR TITLE
Don't double-encode path

### DIFF
--- a/src/cls/_ZPM/PackageManager/Client/REST/PackageManagerClient.cls
+++ b/src/cls/_ZPM/PackageManager/Client/REST/PackageManagerClient.cls
@@ -71,7 +71,7 @@ Method GetModule(pModuleReference As %ZPM.PackageManager.Core.ResolvedModuleRefe
       }
     }
     Set tRequest = ..GetHttpRequest()
-    Set tSC = tRequest.Get($$$URLENCODE(tRequest.Location_path))
+    Set tSC = tRequest.Get(tRequest.Location_path)
     If $$$ISOK(tSC), tRequest.HttpResponse.StatusCode=200 {
       Set tFileBinStream = ##class(%Stream.FileBinary).%New()
       Set tFileBinStream.Filename = ##class(%File).TempFilename("tgz")


### PR DESCRIPTION
The path returned from %Net.URLParser is already URL-encoded; double-encoding it gets a 404.

This bug broke installation of TestCoverage, which I accidentally released with a +snapshot version. (ZPM supports build metadata in semantic versioning; in our parallel use case in HS dev, +snapshot indicates an in-development version.)