### PR TITLE
Fix test result reporting with alt managers

### DIFF
--- a/src/cls/_ZPM/PackageManager/Developer/UnitTest/Manager.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/UnitTest/Manager.cls
@@ -42,7 +42,11 @@ ClassMethod GetLastStatus(Output pFailureCount As %Integer) As %Status
 {
 	Set tSC = $$$OK
 	Try {
-		If $Data(^||%UnitTest.Manager.LastResult,tLogIndex) {
+		If '$Data(^||%UnitTest.Manager.LastResult,tLogIndex)#2 {
+			Set tLogIndex = $Order(^UnitTest.Result(""),-1)
+		}
+		Kill ^||%UnitTest.Manager.LastResult // Clean up
+		If tLogIndex {
 			Set tRes = ##class(%SQL.Statement).%ExecDirect(,"select count(*) "_
 				"from %UnitTest_Result.TestAssert where Status = 0 "_
 				"and TestMethod->TestCase->TestSuite->TestInstance->InstanceIndex = ?",tLogIndex)


### PR DESCRIPTION
This avoids an issue using an alternative unit test manager that doesn't properly set up the PPG - instead, we just use the latest unit test result (which should be right 99% of the time)