### PR TITLE
Allow unit test manager to propagate UserParam array back

### DIFF
--- a/src/cls/_ZPM/PackageManager/Developer/Processor/UnitTest.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/Processor/UnitTest.cls
@@ -111,6 +111,9 @@ Method OnPhase(pPhase As %String, ByRef pParams, Output pResourceHandled As %Boo
 			Set tSC = $ClassMethod(tManagerClass,"RunTest",tTestSpec,tFlags,.tUserParams)
 			ZKill ^UnitTestRoot
 			$$$ThrowOnError(tSC)
+
+			// Allow the manager class to change its own UserParam array for later use in separate test runs
+			Merge pParams("UnitTest","UserParam") = tUserParams
 			
 			If $Data(pParams("UnitTest","JUnitOutput"),tJUnitFile) {
 				Set tPostfix = "-"_$ZConvert(pPhase,"L")_"-"_$Replace(..Package,".","-")


### PR DESCRIPTION
Sample use case is aggregating coverage across multiple suites (or test and verify phases)