### PR TITLE
Exclude CSP files from package resources

### DIFF
--- a/src/cls/_ZPM/PackageManager/Developer/ResourceReference.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/ResourceReference.cls
@@ -106,7 +106,7 @@ Method ResolveChildren(ByRef pResourceArray) As %Status
 			
 			Set tFilesResult = ##class(%SQL.Statement).%ExecDirect(,
         "select Name from  %Library.RoutineMgr_StudioOpenDialog(?,'',1,1,1,0,0)",
-				tPackage_"*")
+				tPackage_"*.cls,"_tPackage_"*.mac,"_tPackage_"*.int,"_tPackage_"*.inc")
 			If (tFilesResult.%SQLCODE < 0) {
 				Set tSC = $$$ERROR($$$SQLCode,tFilesResult.%SQLCODE,tFilesResult.%Message)
 				Quit


### PR DESCRIPTION
Package resources no longer cause a scan of the local files path for all CSP applications, which can cause issues with long filenames on Windows. Fix for #43 