### PR TITLE
Support multiple test resources and running individual test cases/suites

### DIFF
--- a/src/cls/_ZPM/PackageManager/Developer/Processor/UnitTest.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/Processor/UnitTest.cls
@@ -74,10 +74,10 @@ Method OnPhase(pPhase As %String, ByRef pParams, Output pResourceHandled As %Boo
 			}
 			
 			Set tUnitTestDir = ##class(%File).NormalizeDirectory(..ResourceReference.Module.Root_..ResourceReference.Name)
-			Set tUnitTestSubDir = ##class(%File).NormalizeDirectory(tUnitTestDir_$Replace(..Package,".","/"))
+			Set tUnitTestRoot = ##class(%File).NormalizeDirectory(tUnitTestDir_$Replace(..Package,".","/"))
 			Set tTestSpec = ""
 			If $Data(pParams("UnitTest","Suite"),tTestSuite) {
-				Set tTestSubDir = $Replace(tTestSuite,".","\")
+				Set tTestSubDir = $Replace(tTestSuite,".","/")
 				Set tUnitTestDir = ##class(%File).NormalizeDirectory(tUnitTestDir_tTestSubDir)
 			} ElseIf $Data(pParams("UnitTest","Case"),tTestCase) {
 				Set tTestSpec = ":"_tTestCase
@@ -89,11 +89,11 @@ Method OnPhase(pPhase As %String, ByRef pParams, Output pResourceHandled As %Boo
 				If $Data(pParams("UnitTest","Method"),tTestMethod) {
 					Set tTestSpec = tTestSpec_":"_tTestMethod
 				}
+			} Else {
+				Set tUnitTestDir = tUnitTestRoot
 			}
 
-			If ##class(%File).DirectoryExists(tUnitTestSubDir) && (tUnitTestSubDir [ tUnitTestDir) {
-				Set tUnitTestDir = tUnitTestSubDir
-			} ElseIf (tUnitTestSubDir '[ tUnitTestDir) {
+			If (tUnitTestDir '[ tUnitTestRoot) {
 				// Case of multiple unit test resources
 				Quit
 			}


### PR DESCRIPTION
This fixes a bug I introduced in #25 (and a possible cross-OS compatibility issue that would cause issues running a targeted test suite on Linux)

Running a targeted test suite/case will now work, running the test exactly once, even if there are multiple test resources present. (The incorrect behavior was to not run it at all, vs. running it twice before the changes in #25.)

I've tested with a simple repo (objectscript-math) as well as one I have coming that has two separate unit test resources (both running in the test phase).