### PR TITLE
Export module as `package module -p /some/path`

### DIFF
--- a/src/cls/_ZPM/PackageManager.cls
+++ b/src/cls/_ZPM/PackageManager.cls
@@ -94,6 +94,7 @@ This command is an alias for `module-action module-name package`
 <modifier name="dev" dataAlias="DeveloperMode" dataValue="1" description="Sets the DeveloperMode flag for the module's lifecycle. Key consequences of this are that ^Sources will be configured for resources in the module, and installer methods will be called with the dev mode flag set." />
 <modifier name="quiet" aliases="q" dataAlias="Verbose" dataValue="0" description="Produces minimal output from the command." />
 <modifier name="verbose" aliases="v" dataAlias="Verbose" dataValue="1" description="Produces verbose output from the command." />
+<modifier name="path" aliases="p" dataAlias="Path" value="true" description="Use specified path to export package." />
 </command>
 
 <command name="verify">

--- a/src/cls/_ZPM/PackageManager/Developer/Lifecycle/Module.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/Lifecycle/Module.cls
@@ -52,7 +52,15 @@ Method %Package(ByRef pParams) As %Status
 	Set tSC = $$$OK
 	Try {
 		Set tVerbose = $Get(pParams("Verbose"))
-		
+		Set tExportDirectory = $Get(pParams("zpm", "Path"))
+		If (tExportDirectory'="") && ('##class(%File).DirectoryExists(tExportDirectory)) {
+      Set tExportDirectory = ##class(%File).NormalizeDirectory(tExportDirectory)
+			If '##class(%File).CreateDirectoryChain(tExportDirectory,.tReturn) {
+				Set tSC = $$$ERROR($$$GeneralError,$$$FormatText("Error creating directory chain %1: %2",tExportDirectory,tReturn))
+				Quit
+			}
+		}
+
 		Set tSC = ..%Export(.pParams,.tExportDirectory)
 		If $$$ISERR(tSC) {
 			Quit
@@ -63,7 +71,7 @@ Method %Package(ByRef pParams) As %Status
 			Quit
 		}
 		
-		Write !,"Module exported to:",!,$c(9),tExportDirectory,!
+		Write !,"Module exported to:",!,$Char(9),tExportDirectory,!
 		
 		Set tTgzFile = $Extract(tExportDirectory,1,*-1)_".tgz"
 		Set tSC = ##class(%ZPM.PackageManager.Developer.Archive).Create(tExportDirectory,tTgzFile,.tOutput)
@@ -76,7 +84,7 @@ Method %Package(ByRef pParams) As %Status
 		}
 		
 		// Always show this message
-		Write !,"Module package generated:",!,$c(9),tTgzFile
+		Write !,"Module package generated:",!,$Char(9),tTgzFile
 		
 		Set tSrcFileStream = ##class(%Stream.FileBinary).%New()
 		Set tSC = tSrcFileStream.LinkToFile(tTgzFile)


### PR DESCRIPTION
Fix #163 

```
USER>zpm "package resourcetest -only -p /tmp/test "

[resourcetest]  Package START
Module exported to:
        /tmp/test

Module package generated:
        /tmp/tes.tgz
[resourcetest]  Package SUCCESS
```