### PR TITLE
improvements for FileCopy

### DIFF
--- a/src/cls/_ZPM/PackageManager/Developer/Processor/Abstract.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/Processor/Abstract.cls
@@ -26,7 +26,7 @@ Method %OnNew(pResourceReference As %ZPM.PackageManager.Developer.ResourceRefere
 
 Method SetParams(ByRef pParams) As %Status
 {
-	if ($Data(pParams)) {
+	If ($Data(pParams)) {
 		Merge ..Params = pParams
 		Do ..CopyAttributes()
 		Do ..ApplyDefaults()
@@ -46,13 +46,18 @@ Method CopyAttributes() [ CodeMode = objectgenerator, Private ]
 					Set tMsg = $$$FormatText("Invalid property in ATTRIBUTES list: '%1'",tAttribute)
 					$$$ThrowStatus($$$ERROR($$$GeneralError,tMsg))
 				}
-				Do %code.WriteLine(" Set tIsDefined = ..ResourceReference.Attributes.IsDefined("""_tAttribute_""")")
-				Do %code.WriteLine(" If tIsDefined {")
-				Do %code.Write("  Set .."_tAttribute_" = ")
-				Set tDataType = $$$comMemberKeyGet(%compiledclass.Name,$$$cCLASSproperty,tAttribute,$$$cPROPruntimetype)
-				Set tAttrValue = "..%Evaluate(..ResourceReference.Attributes.GetAt("""_tAttribute_"""))"
-				Do %code.WriteLine("$Select($$$comMemberDefined($classname(),$$$cCLASSmethod,"""_tAttribute_"XSDToLogical""):$classmethod($classname(),"""_tAttribute_"XSDToLogical"","_tAttrValue_"),1:"_tAttrValue_")")
-				Do %code.WriteLine(" }")
+        Set tProps = $ListFromString($$$defMemberKeyGet(%compiledclass.Name,$$$cCLASSproperty,tAttribute,$$$cPROPaliases))
+        Set tProps = tProps _ $lb(tAttribute)
+        set tPtr1 = 0
+        while $ListNext(tProps, tPtr1, tAttribute) {
+          Do %code.WriteLine(" Set tIsDefined = ..ResourceReference.Attributes.IsDefined("""_tAttribute_""")")
+          Do %code.WriteLine(" If tIsDefined {")
+          Do %code.Write("  Set .."_tAttribute_" = ")
+          Set tDataType = $$$comMemberKeyGet(%compiledclass.Name,$$$cCLASSproperty,tAttribute,$$$cPROPruntimetype)
+          Set tAttrValue = "..%Evaluate(..ResourceReference.Attributes.GetAt("""_tAttribute_"""))"
+          Do %code.WriteLine("$Select($$$comMemberDefined($classname(),$$$cCLASSmethod,"""_tAttribute_"XSDToLogical""):$classmethod($classname(),"""_tAttribute_"XSDToLogical"","_tAttrValue_"),1:"_tAttrValue_")")
+          Do %code.WriteLine(" }")
+        }
 			}
 		}
 		
@@ -71,7 +76,7 @@ Method ApplyDefaults()
 		Set tDefault = tDefaults.GetAt(tDefaultIndex)
 		If tDefault.%IsA("%ZPM.PackageManager.Developer.ModuleSetting.ProcessorDefault") {
 			#dim tDefault As %ZPM.PackageManager.Developer.ModuleSetting.ProcessorDefault
-			Set tThisClass = $classname()
+			Set tThisClass = $ClassName()
 			Set tFullClass = $$$DefaultProcessorPackageDot_tDefault.Class
 			If (tThisClass = tDefault.Class) || (tThisClass = tFullClass) {
 				Set tSatisfiesConditions = 1
@@ -230,15 +235,22 @@ Method %Evaluate(pAttrValue) As %String [ Internal ]
 	}
 	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\{\$namespace\}",$Namespace)
 	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\$\{namespace\}",$Namespace)
-	Set tMgrDir = ##class(%File).ManagerDirectory()
+  Set tInstallDir = $System.Util.InstallDirectory()
+	Set tMgrDir = $System.Util.ManagerDirectory()
 	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\{\$mgrdir\}",tMgrDir)
 	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\$\{mgrdir\}",tMgrDir)
-	Set tCSPDir = ##class(%File).NormalizeDirectory(##class(%File).ParentDirectoryName(tMgrDir)_"/csp")
+	Set tCSPDir = ##class(%File).NormalizeDirectory("csp", tInstallDir)
 	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\{\$cspdir\}",tCSPDir)
 	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\$\{cspdir\}",tCSPDir)
 	Set tRoot = $Case(..ResourceReference.Module.Root,"":"",:##class(%File).NormalizeDirectory(..ResourceReference.Module.Root))
 	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\{\$root\}",tRoot)
 	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\$\{root\}",tRoot)
+  Set tBinDir = $System.Util.BinaryDirectory()
+	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\{\$bindir\}",tBinDir)
+	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\$\{bindir\}",tBinDir)
+  Set tLibDir = ##class(%File).NormalizeDirectory("lib", tInstallDir)
+	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\{\$libdir\}",tLibDir)
+	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\$\{libdir\}",tLibDir)
 	Quit tAttrValue
 }
 

--- a/src/cls/_ZPM/PackageManager/Developer/Processor/FileCopy.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/Processor/FileCopy.cls
@@ -7,9 +7,9 @@ Parameter DESCRIPTION As STRING = "Copies the specified directory (the resource 
 /// Comma-separated list of resource attribute names that this processor uses
 Parameter ATTRIBUTES As STRING = "InstallDirectory,Overlay";
 
-/// Directory to which the directory should be copied upon installation; may contain expressions.
-Property InstallDirectory As %String(MAXLEN = "") [ Required ];
+Property InstallDirectory As %String(MAXLEN = "") [ Aliases = {Target,Dest} ];
 
+/// Directory to which the directory should be copied upon installation; may contain expressions.
 /// If true, the files should be added to the target location (rather than fully replacing it, causing other files there to be deleted)
 Property Overlay As %Boolean;
 
@@ -22,12 +22,25 @@ Method OnBeforePhase(pPhase As %String, ByRef pParams) As %Status
 		If $$$ISERR(tSC) {
 			Quit
 		}
-		
+
 		If (pPhase = "Activate") && (..InstallDirectory '= "") {
-			Set tSourceDir = ##class(%File).NormalizeDirectory(..ResourceReference.Module.Root_..ResourceReference.Name)
+			Set tSourceDir = ##class(%File).NormalizeFilename(..ResourceReference.Module.Root _ ..ResourceReference.Name)
 			Set tTargetDir = ##class(%File).NormalizeDirectory(..InstallDirectory)
 			Write !,"Copying ",tSourceDir," to ",tTargetDir
-			Set tSC = ##class(%ZPM.PackageManager.Developer.File).CopyDir(tSourceDir,tTargetDir,'..Overlay)
+      If '##class(%File).DirectoryExists(tTargetDir) {
+        If '##class(%File).CreateDirectoryChain(tTargetDir,.tReturn) {
+          Set tSC = $$$ERROR($$$GeneralError,$$$FormatText("Error creating directory %1: %2",tTargetDir,$ZUtil(209,tReturn)))
+          Quit
+        }
+      }
+      If ##class(%File).DirectoryExists(tSourceDir) {
+        Write " as directory "
+			  Set tSC = ##class(%ZPM.PackageManager.Developer.File).CopyDir(tSourceDir,tTargetDir,'..Overlay)
+      }
+      Else {
+        Write " as file "
+			  Set tSC = ##class(%File).CopyFile(tSourceDir, tTargetDir, '..Overlay)
+      }
 		}
 	} Catch e {
 		Set tSC = e.AsStatus()


### PR DESCRIPTION
Example of module.xml
```
<?xml version="1.0" encoding="UTF-8"?>
<Export generator="Cache" version="25">
  <Document name="test-binary.ZPM">
    <Module>
      <Name>test-binary</Name>
      <Version>0.0.1</Version>
      <Packaging>module</Packaging>
      <SourcesRoot>src</SourcesRoot>
      <FileCopy Name="lib" Target="${libdir}my-lib"/> <!-- Copies content of lib folder to target -->
      <FileCopy Name="somefile.jar" Target="${libdir}my-lib"/> <!-- Copies just desired file to target -->
    </Module>
  </Document>
</Export>
```

Added some improvements to already existing tag `FileCopy`

- Added aliases `Target` and `Dest` to attribute `InstallDirectory`
- Supports files as well as directories, no wildcards, just folder content of which should be copied, or particular file
- `${libdir}`,`${bindir}` added, installdir/lib and installdir/bin respectively. using bindir in docker environments may cause to security issues during install. Using libdir works in this case, so, recommended way.

fix for #174 