### PR TITLE
added improvements to Invoke

### DIFF
--- a/src/cls/_ZPM/PackageManager/Developer/Document/Module.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/Document/Module.cls
@@ -393,11 +393,11 @@ XData InternalXSL
     <xsl:for-each select="@*">
       <xsl:element name="Attribute">
         <xsl:attribute name="Name">
-        <xsl:choose>
-		  <xsl:when test="name()='SourcePath'">Path</xsl:when>
-		  <xsl:when test="name()='DeployPath'">Directory</xsl:when>
-		  <xsl:otherwise><xsl:value-of select="name()" /></xsl:otherwise>
-		</xsl:choose>
+          <xsl:choose>
+            <xsl:when test="name()='SourcePath'">Path</xsl:when>
+            <xsl:when test="name()='DeployPath'">Directory</xsl:when>
+            <xsl:otherwise><xsl:value-of select="name()" /></xsl:otherwise>
+          </xsl:choose>
         </xsl:attribute>
         <xsl:value-of select="." />
       </xsl:element>
@@ -411,7 +411,7 @@ XData InternalXSL
 				<xsl:attribute name="ProcessorClass">
 					<xsl:value-of select="name()" />
 				</xsl:attribute>
-			</xsl:if>
+      </xsl:if>
       <xsl:attribute name="Name">
         <xsl:value-of select="@*[name()=$name]" />
       </xsl:attribute>
@@ -444,6 +444,11 @@ XData InternalXSL
     </xsl:call-template>
   </xsl:template>
 
+  <xsl:template match="Module/Invoke">
+    <xsl:element name="Invokes">
+      <xsl:copy-of select="." />
+    </xsl:element>
+  </xsl:template>
   <xsl:template match="Module/Resource">
     <xsl:call-template name="resource">
       <xsl:with-param name="name" select="'Name'" />

--- a/src/cls/_ZPM/PackageManager/Developer/InvokeReference.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/InvokeReference.cls
@@ -1,21 +1,63 @@
 Class %ZPM.PackageManager.Developer.InvokeReference Extends (%Persistent, %ZPM.PackageManager.Core.InvokeReference)
 {
 
-Property Class As %String(MAXLEN = 255, XMLPROJECTION = "ATTRIBUTE");
+Property Class As %String(MAXLEN = 255, XMLPROJECTION = "ATTRIBUTE") [ Required ];
 
-Property Method As %String(MAXLEN = 255, XMLPROJECTION = "ATTRIBUTE");
+Property Method As %String(MAXLEN = 255, XMLPROJECTION = "ATTRIBUTE") [ Required ];
+
+Property Phase As %String(MAXLEN = 255, XMLPROJECTION = "ATTRIBUTE") [ InitialExpression = "Configure" ];
+
+Property When As %String(MAXLEN = 255, VALUELIST = ",Before,After", XMLPROJECTION = "ATTRIBUTE") [ InitialExpression = "After" ];
+
+Property CheckStatus As %Boolean(XMLPROJECTION = "ATTRIBUTE") [ InitialExpression = 0 ];
 
 Property Arg As list Of %String(XMLNAME = "Arg", XMLPROJECTION = "ELEMENT");
 
 Relationship Module As %ZPM.PackageManager.Developer.Module(XMLPROJECTION = "NONE") [ Cardinality = parent, Inverse = Invokes ];
 
-Method GetArgsArray(args) As %Status
+Method GetArgsArray(pParams, Output args) As %Status
 {
-		Set args = ..Arg.Count()
-		For i=1:1:..Arg.Count() {
-			Set args(i) = ..Arg.GetAt(i)
-			If (args(i)=$c(0)) { Set args(i) = "" }
-		}
+  Set args = ..Arg.Count()
+  For i=1:1:..Arg.Count() {
+    Set args(i) = ..Module.%Evaluate(..Arg.GetAt(i), .pParams)
+    If (args(i)=$Char(0)) { Set args(i) = "" }
+  }
+}
+
+Method OnBeforePhase(pPhase As %String, ByRef pParams) As %Status
+{
+  If (pPhase '= ..Phase) || ("Before" '= ..When) {
+	  Quit $$$OK
+  }
+
+	Quit ..doInvoke(.pParams)
+}
+
+Method OnAfterPhase(pPhase As %String, ByRef pParams) As %Status
+{
+  If (pPhase '= ..Phase) || ("After" '= ..When) {
+	  Quit $$$OK
+  }
+
+	Quit ..doInvoke(.pParams)
+}
+
+Method doInvoke(ByRef pParams) As %Status
+{
+  Set tSC = $$$OK
+  Do ..GetArgsArray(.pParams, .args)
+
+  Try {
+    If ..CheckStatus {
+      Set tSC = $ClassMethod(..Class, ..Method, args...)
+    } Else {
+      Do $ClassMethod(..Class, ..Method, args...)
+    }
+  } Catch ex {
+    Set tSC = ex.AsStatus()
+  }
+
+  Quit tSC
 }
 
 Storage Default
@@ -32,6 +74,15 @@ Storage Default
 </Value>
 <Value name="4">
 <Value>Arg</Value>
+</Value>
+<Value name="5">
+<Value>Phase</Value>
+</Value>
+<Value name="6">
+<Value>CheckStatus</Value>
+</Value>
+<Value name="7">
+<Value>When</Value>
 </Value>
 </Data>
 <DataLocation>{%%PARENT}("Invokes")</DataLocation>

--- a/src/cls/_ZPM/PackageManager/Developer/Lifecycle/Base.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/Lifecycle/Base.cls
@@ -294,26 +294,6 @@ Method %Configure(ByRef pParams) As %Status
 			// Call OnConfigureComponent
 			Set tSC = $ClassMethod(..Module.InstallerClass,"OnConfigureComponent",$Namespace,tVerbose,.tVars)
 		}
-
-		// Call Invoke Methods
-		
-		Set key = ""
-		For {
-			Set invoke = ..Module.Invokes.GetNext(.key)
-			Quit:(key = "")
-			Set args = 0
-			Do invoke.GetArgsArray(.args)
-
-			Do ##class(%ZPM.PackageManager.Developer.ModuleSetting.Default).EvaluateArgs(.args, .customParams)
-
-			If (tVerbose) { 
-				Write !, $$$FormatText("Invoking ClassMethod %1 from Class %2 ... ",invoke.Method,invoke.Class) 
-				Set result = $ClassMethod(invoke.Class,invoke.Method,args...)
-				Write $$$FormatText("Result: %1 ",result)
-			} else {
-				Do $ClassMethod(invoke.Class,invoke.Method,args...)
-			}
-		}
 	} Catch e {
 		Set tSC = e.AsStatus()
 	}

--- a/src/cls/_ZPM/PackageManager/Developer/Module.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/Module.cls
@@ -149,14 +149,35 @@ ClassMethod ExecutePhases(pModuleName As %String, pPhases As %List, pIsComplete 
 						set tSC = $method(tResource.Processor,"OnBeforePhase",tOnePhase,.pParams) quit:$$$ISERR(tSC)
 					}
 				}
-				quit:$$$ISERR(tSC)
+				Quit:$$$ISERR(tSC)
+
+        #; Call Invoke Methods		
+        Set tKey = ""
+        For {
+          Set tInvoke = tModule.Invokes.GetNext(.tKey)
+          Quit:(tKey = "")
+          Set tSC = tInvoke.OnBeforePhase(tOnePhase,.pParams)
+          Quit:$$$ISERR(tSC)
+        }
+        Quit:$$$ISERR(tSC)
+
 				; call OnBeforePhase for this class
 				set tSC = tLifecycle.OnBeforePhase(tOnePhase,.pParams) quit:$$$ISERR(tSC)
 				;
 				set tSC = $method(tLifecycle,"%"_tOnePhase,.pParams) quit:$$$ISERR(tSC)
 				;
 				; call OnAfterPhase for this class
-				set tSC = tLifecycle.OnAfterPhase(tOnePhase,.pParams) quit:$$$ISERR(tSC)
+
+        #; Call Invoke Methods After Phase	
+        Set tKey = ""
+        For {
+          Set tInvoke = tModule.Invokes.GetNext(.tKey)
+          Quit:(tKey = "")
+          Set tSC = tInvoke.OnAfterPhase(tOnePhase,.pParams)
+          Quit:$$$ISERR(tSC)
+        }
+        Quit:$$$ISERR(tSC)
+
 				; notify resource processors
 				set tKey="" for {
 					set tResource = tModule.Resources.GetNext(.tKey) quit:(tKey="")			
@@ -871,6 +892,44 @@ Query VersionRequirements(pOfModuleName As %String, pExcludeModuleNames As %List
 	from %ZPM_PackageManager_Developer.Module_Dependencies
 	where Dependencies_Name = :pOfModuleName and
 		(:pExcludeModuleNames is null or "Module"->Name not %INLIST :pExcludeModuleNames)
+}
+
+ClassMethod %RegExReplace(pString, pName, pValue) As %String [ Private ]
+{
+  Set tRegEx = "(?i)\{\$" _ pName _ "\}"
+	Set value =  ##class(%Regex.Matcher).%New(tRegEx, pString).ReplaceAll($Replace(pValue,"\","\\"))
+  Set tRegEx = "(?i)\$\{" _ pName _ "\}"
+	Set value =  ##class(%Regex.Matcher).%New(tRegEx, pString).ReplaceAll($Replace(pValue,"\","\\"))
+  Quit value
+}
+
+/// Evaluates an expression in an attribute
+/// Current valid expressions:
+/// {$namespace} - the current namespace
+/// {$mgrdir} - the instance's mgr directory
+/// {$cspdir} - the instance's root CSP directory
+/// {$root} - the resource's module's root directory
+/// These special expressions are case-insensitive.
+Method %Evaluate(pAttrValue, ByRef pParams) As %String [ Internal ]
+{
+	Set tAttrValue = pAttrValue
+	Set tRoot = $Case(..Root,"":"",:##class(%File).NormalizeDirectory(..Root))
+  Set tInstallDir = $System.Util.InstallDirectory()
+	Set tMgrDir = $System.Util.ManagerDirectory()
+  Set tBinDir = $System.Util.BinaryDirectory()
+	Set tCSPDir = ##class(%File).NormalizeDirectory("csp", tInstallDir)
+  Set tLibDir = ##class(%File).NormalizeDirectory("lib", tInstallDir)
+  Set tVerbose = +$Get(pParams("Verbose"))
+
+	Set tAttrValue = ..%RegExReplace(tAttrValue, "namespace", $Namespace)
+	Set tAttrValue = ..%RegExReplace(tAttrValue, "ns", $Namespace)
+	Set tAttrValue = ..%RegExReplace(tAttrValue, "mgrdir",    tMgrDir)
+	Set tAttrValue = ..%RegExReplace(tAttrValue, "cspdir",    tCSPDir)
+	Set tAttrValue = ..%RegExReplace(tAttrValue, "root",      tRoot)
+	Set tAttrValue = ..%RegExReplace(tAttrValue, "bindir",    tBinDir)
+	Set tAttrValue = ..%RegExReplace(tAttrValue, "libdir",    tLibDir)
+	Set tAttrValue = ..%RegExReplace(tAttrValue, "verbose",   tVerbose)
+	Quit tAttrValue
 }
 
 Storage Default

--- a/src/cls/_ZPM/PackageManager/Developer/Processor/Abstract.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/Processor/Abstract.cls
@@ -233,30 +233,8 @@ Method %Evaluate(pAttrValue) As %String [ Internal ]
 		Do ##class(%ZPM.PackageManager.Developer.ModuleSetting.Default).GetCustomParameters(.customParams,..ResourceReference.Module, .tParams)
 		Set tAttrValue = ##class(%ZPM.PackageManager.Developer.ModuleSetting.Default).EvaluateAttribute(tAttrValue,.customParams)
 	}
-	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\{\$namespace\}",$Namespace)
-	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\$\{namespace\}",$Namespace)
-  Set tInstallDir = $System.Util.InstallDirectory()
-	Set tMgrDir = $System.Util.ManagerDirectory()
-	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\{\$mgrdir\}",tMgrDir)
-	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\$\{mgrdir\}",tMgrDir)
-	Set tCSPDir = ##class(%File).NormalizeDirectory("csp", tInstallDir)
-	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\{\$cspdir\}",tCSPDir)
-	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\$\{cspdir\}",tCSPDir)
-	Set tRoot = $Case(..ResourceReference.Module.Root,"":"",:##class(%File).NormalizeDirectory(..ResourceReference.Module.Root))
-	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\{\$root\}",tRoot)
-	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\$\{root\}",tRoot)
-  Set tBinDir = $System.Util.BinaryDirectory()
-	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\{\$bindir\}",tBinDir)
-	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\$\{bindir\}",tBinDir)
-  Set tLibDir = ##class(%File).NormalizeDirectory("lib", tInstallDir)
-	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\{\$libdir\}",tLibDir)
-	Set tAttrValue = ..%RegExReplace(tAttrValue,"(?i)\$\{libdir\}",tLibDir)
-	Quit tAttrValue
-}
 
-ClassMethod %RegExReplace(pString, pRegEx, pValue) As %String [ Private ]
-{
-	Quit ##class(%Regex.Matcher).%New(pRegEx,pString).ReplaceAll($Replace(pValue,"\","\\"))
+  Quit ..ResourceReference.Module.%Evaluate(tAttrValue)
 }
 
 ClassMethod GetDescription(pClassName As %String) As %String [ SqlProc ]

--- a/tests/integration_tests/Test/PM/Integration/InstallModule.cls
+++ b/tests/integration_tests/Test/PM/Integration/InstallModule.cls
@@ -1,0 +1,18 @@
+Class Test.PM.Integration.InstallModule Extends Test.PM.Integration.Base
+{
+
+Method TestSimpleApp()
+{
+  Set tSC = $$$OK
+  Try {
+    Set tTestRoot = ##class(%File).NormalizeDirectory($Get(^UnitTestRoot))
+
+    Set tModuleDir = ##class(%File).NormalizeDirectory(##class(%File).GetDirectory(tTestRoot)_"/_data/simple-module/")
+    Set tSC = ##class(%ZPM.PackageManager).Shell("load "_tModuleDir)
+    Do $$$AssertStatusOK(tSC,"Loaded SimpleModule module successfully.")
+  } Catch e {
+    Do $$$AssertStatusOK(e.AsStatus(),"An exception occurred.")
+  }
+}
+
+}

--- a/tests/integration_tests/Test/PM/Integration/_data/simple-app/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/simple-app/module.xml
@@ -4,6 +4,10 @@
   <Name>SimpleApp</Name>
   <Version>0.0.1+snapshot</Version>
   <Packaging>application</Packaging>
+  <Invoke Class="%EnsembleMgr" Method="EnableNamespace" Phase="Compile" When="Before" CheckStatus="true">
+    <Arg>${namespace}</Arg>
+    <Arg>${verbose}</Arg>
+  </Invoke>
   <Resources>
     <Resource Name="TSL.SimpleAppInclude.INC" Preload="true">
     </Resource>

--- a/tests/integration_tests/Test/PM/Integration/_data/simple-module/module.xml
+++ b/tests/integration_tests/Test/PM/Integration/_data/simple-module/module.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+  <Document name="simplemodule.ZPM">
+    <Module>
+      <Name>simplemodule</Name>
+      <Version>0.0.1+snapshot</Version>
+      <Packaging>application</Packaging>
+      <SourcesRoot>src</SourcesRoot>
+      <Resource Name="Test.pkg"/>
+      <Invoke Class="%EnsembleMgr" Method="EnableNamespace" Phase="Compile" When="Before" CheckStatus="true">
+        <Arg>${namespace}</Arg>
+        <Arg>${verbose}</Arg>
+      </Invoke>
+    </Module>
+  </Document>
+</Export>

--- a/tests/integration_tests/Test/PM/Integration/_data/simple-module/src/Test/Test.cls
+++ b/tests/integration_tests/Test/PM/Integration/_data/simple-module/src/Test/Test.cls
@@ -1,0 +1,4 @@
+Class Test.Test
+{
+
+}


### PR DESCRIPTION
Fix for #181 
Fix for #178 

Don't need wrapper tag <Invokes> anymore
Added a few more attributes:

- CheckStatus (Default: false), expects that invoked method returns %Status, and use it to check the status of installation.
- Phase, (Default: Configure), the phase during which it should be executed
- When, (Default: After), values: Before and After. To execute before or after the main execution for the phase

added support for variables, added `${verbose}` variable
```
<Invoke Class="%EnsembleMgr" Method="EnableNamespace" Phase="Compile" When="Before" CheckStatus="true">
  <Arg>${namespace}</Arg>
  <Arg>${verbose}</Arg>
</Invoke>
```