### PR TITLE
fail installation if source file does not exist in FileCopy

### DIFF
--- a/src/cls/_ZPM/PackageManager/Developer/Document/Module.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/Document/Module.cls
@@ -324,6 +324,7 @@ Method ImportFromXML(stream As %RegisteredObject, flags As %String) As %Status
 
 	Set tSC = ##class(%XML.XSLT.Transformer).TransformStream(stream, tXSL, .tOutput)
 	If $$$ISERR(tSC) Quit tSC
+  #; do tOutput.OutputToDevice()
 	
 	Do ..Code.Clear()
 	#; Do ..Code.WriteLine("<?xml version=""1.0""?>") //add XML header
@@ -443,10 +444,16 @@ XData InternalXSL
       <xsl:with-param name="name" select="'Url'" />
     </xsl:call-template>
   </xsl:template>
-
   <xsl:template match="Module/Invoke">
     <xsl:element name="Invokes">
       <xsl:copy-of select="." />
+    </xsl:element>
+  </xsl:template>
+  <xsl:template match="Module/Default|Module/Parameter">
+    <xsl:element name="Defaults">
+      <xsl:element name="Default">
+        <xsl:copy-of select="./@*" />
+      </xsl:element>
     </xsl:element>
   </xsl:template>
   <xsl:template match="Module/Resource">

--- a/src/cls/_ZPM/PackageManager/Developer/Module.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/Module.cls
@@ -923,14 +923,32 @@ Method %Evaluate(pAttrValue, ByRef pParams) As %String [ Internal ]
   Set tVerbose = +$Get(pParams("Verbose"))
 
 	Set tAttrValue = ..%RegExReplace(tAttrValue, "namespace", $Namespace)
-	Set tAttrValue = ..%RegExReplace(tAttrValue, "ns", $Namespace)
+	Set tAttrValue = ..%RegExReplace(tAttrValue, "ns",        $Namespace)
 	Set tAttrValue = ..%RegExReplace(tAttrValue, "mgrdir",    tMgrDir)
 	Set tAttrValue = ..%RegExReplace(tAttrValue, "cspdir",    tCSPDir)
 	Set tAttrValue = ..%RegExReplace(tAttrValue, "root",      tRoot)
 	Set tAttrValue = ..%RegExReplace(tAttrValue, "bindir",    tBinDir)
 	Set tAttrValue = ..%RegExReplace(tAttrValue, "libdir",    tLibDir)
 	Set tAttrValue = ..%RegExReplace(tAttrValue, "verbose",   tVerbose)
+
+  Set regex = ##class(%Regex.Matcher).%New("#\{([^}]+)\}", tAttrValue)
+  While regex.Locate() {
+    Set expr = regex.Group(1)
+    Set value = ..%EvalueateExpression(expr)
+    Set $Extract(tAttrValue, regex.Start, regex.End - 1) = value
+    Set regex.Text = tAttrValue
+  }
+  
 	Quit tAttrValue
+}
+
+Method %EvalueateExpression(pExpr) As %String [ Internal ]
+{
+  Try {
+    return @pExpr
+  } Catch ex {
+  }
+  Return ""
 }
 
 Storage Default

--- a/src/cls/_ZPM/PackageManager/Developer/Processor/FileCopy.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/Processor/FileCopy.cls
@@ -5,7 +5,9 @@ Class %ZPM.PackageManager.Developer.Processor.FileCopy Extends %ZPM.PackageManag
 Parameter DESCRIPTION As STRING = "Copies the specified directory (the resource name) to a specific target location (InstallDirectory) during the Activate phase.";
 
 /// Comma-separated list of resource attribute names that this processor uses
-Parameter ATTRIBUTES As STRING = "InstallDirectory,Overlay";
+Parameter ATTRIBUTES As STRING = "Name,InstallDirectory,Overlay";
+
+Property Name As %String(MAXLEN = "");
 
 Property InstallDirectory As %String(MAXLEN = "") [ Aliases = {Target,Dest} ];
 
@@ -25,7 +27,7 @@ Method OnBeforePhase(pPhase As %String, ByRef pParams) As %Status
 		}
 
 		If (pPhase = "Activate") && (..InstallDirectory '= "") {
-      Set tSource = ..ResourceReference.Module.Root _ ..ResourceReference.Name
+      Set tSource = ..ResourceReference.Module.Root _ ..Name
       Set tTarget = ..InstallDirectory
       Set tSC = ..DoCopy(tSource, tTarget, .pParams)
       If $$$ISERR(tSC) {
@@ -97,8 +99,13 @@ Method DoCopy(tSource, tTarget, pParams)
     Write:tVerbose !,"Copying ",tSource," to ",tTarget
     If (copyAsFile) {
       Write:tVerbose " as file "
+      If '##class(%File).Exists(tSource) {
+        Set tSC = $$$ERROR($$$GeneralError, "Source file does not exists")
+        Quit
+      }
       If '##class(%File).CopyFile(tSource, tTarget,'..Overlay, .return) {
-        Set tSC = $Get(%objlasterror, return)
+        Set tSC = $$$ERROR($$$GeneralError, "File not copied: " _ return)
+        Quit
       }
     }
     Else {


### PR DESCRIPTION
Fixes #191
Fixes #190 

Added Alias `Parameter` to `Default` tag, Defaults tag unnecessary anymore
```
<Defaults>
  <Default Name="config" Value="test">
</Defaults>
```
Now the same to
```
<Default Name="config" Value="test">
```
Or even
```
<Parameter Name="config" Value="test">
```

added evaluation expression for anything between `#{` and `}`
`#{$zconvert($namespace,"L")}` will return the current Namespace in lowercase
XML allows using single quotes, so, if the expression contains double quotes, it should be surrounded by single quotes in XML
```
<Parameter Name="config" Value='#{$zconvert($namespace,"l")}'/>
<FileCopy Name="dsw/irisapp.json" Target="${cspdir}dsw/configs/${config}.json"/>
```
