### PR TITLE
Added TerminalPrompt parameter to configuration ZPM. Task completed #154

### DIFF
--- a/src/cls/_ZPM/PackageManager.cls
+++ b/src/cls/_ZPM/PackageManager.cls
@@ -327,6 +327,25 @@ ClassMethod Shell(pCommand As %String, pTerminateOnError As %Boolean = 0, pHaltO
 	Quit tSC
 }
 
+ClassMethod TerminalPrompt() As %String
+{
+	set tp=##class(%SYSTEM.Process).TerminalPrompt()
+	set prompt="zpm:"
+	set del=$Case(##class(%ZPM.PackageManager.Client.Settings).GetValue("TerminalPrompt"),"green":$$$escGreen(">"),"red":$$$escRed(">"),"violet":$$$escViolet(">"),"yellow":$$$escYellow(">"),"blue":$$$escBlue(">"),:">")
+	if del=">" set tp=2
+	for i=1:1:$l(tp,",") {
+		if $p(tp,",",i)=1 {	set prompt=prompt_$p($system,":")_del continue}
+		elseif $p(tp,",",i)=2 {	set prompt=prompt_$namespace_del continue}
+		elseif $p(tp,",",i)=3 {	set prompt=prompt_$p($system,":",2)_del continue}
+		elseif $p(tp,",",i)=4 {	set prompt=prompt_$zt(+$p($h,",",2),1)_del continue}
+		elseif $p(tp,",",i)=5 {	set prompt=prompt_$job_del continue}
+		elseif $p(tp,",",i)=6 {	set prompt=prompt_$username_del continue}
+		;i think for zapm shell 7 and 8 do not need to be implemented
+	}
+	quit prompt
+}
+
+
 /// For use in unit tests that need to test if a command threw any exceptions.
 ClassMethod ShellInternal(pCommand As %String, Output pException As %Exception.AbstractException) [ Internal ]
 {
@@ -339,7 +358,7 @@ ClassMethod ShellInternal(pCommand As %String, Output pException As %Exception.A
 	For {
 		Try {
 			If (tCommand = "") {
-				Write "zpm: ",$Namespace,">"
+				Write ..TerminalPrompt()
 				Read tCommand
 				Write !
 			}

--- a/src/cls/_ZPM/PackageManager.cls
+++ b/src/cls/_ZPM/PackageManager.cls
@@ -978,6 +978,30 @@ ClassMethod Load(ByRef pCommandInfo) [ Internal ]
 {
 	Set tDirectoryName = $Get(pCommandInfo("parameters","path"))
 	Merge tParams = pCommandInfo("data")
+	if $EXTRACT(tDirectoryName,1,4)="http" {
+		set slash=$s($zversion(1)=3:"/",1:"\")
+		//set TempDir = $$$FileTempDir
+		set TempDir = ##class(%File).GetDirectory(##class(%File).GetDirectory($zu(86))_"mgr"_slash_"Temp"_slash_$tr($zts,".,")_slash)
+		$$$ThrowOnError(##class(%File).CreateDirectoryChain(TempDir))
+
+		set RepoName=$p($p(tDirectoryName,"/",*),".git")
+		set tCmd="cd "_TempDir_" && git clone "_tDirectoryName
+		$$$ThrowOnError(##class(%ZPM.PackageManager.Developer.Utils).RunCommandViaZF(tCmd,.tLog,.tErr))
+
+      	If ($Get(tParams("Verbose"))) {
+			write !,"Create tempory directory "_TempDir
+			write !,tCmd
+        	For i=1:1:$Get(tLog) {
+          		Write tLog(i),!
+        	}
+      	}
+       	For i=1:1:$Get(tErr) {
+       		Write tErr(i),!
+       	}
+		hang 2
+		set tDirectoryName = TempDir_slash_RepoName
+	}
+
 	If ##class(%File).DirectoryExists(tDirectoryName) {
 		$$$ThrowOnError(##class(%ZPM.PackageManager.Developer.Utils).LoadNewModule(tDirectoryName,.tParams))
 	} ElseIf ##class(%File).Exists(tDirectoryName),$$$lcase($PIECE(tDirectoryName, ".", *)) = "tgz" {

--- a/src/cls/_ZPM/PackageManager.cls
+++ b/src/cls/_ZPM/PackageManager.cls
@@ -331,8 +331,8 @@ ClassMethod TerminalPrompt() As %String
 {
 	set tp=##class(%SYSTEM.Process).TerminalPrompt()
 	set prompt="zpm:"
-	set del=$Case(##class(%ZPM.PackageManager.Client.Settings).GetValue("TerminalPrompt"),"green":$$$escGreen(">"),"red":$$$escRed(">"),"violet":$$$escViolet(">"),"yellow":$$$escYellow(">"),"blue":$$$escBlue(">"),:">")
-	if del=">" set tp=2
+	set del=$Case(##class(%ZPM.PackageManager.Client.Settings).GetValue("TerminalPrompt"),"green":$$$escGreen(">"),"red":$$$escRed(">"),"violet":$$$escViolet(">"),"yellow":$$$escYellow(">"),"blue":$$$escBlue(">"),"none":"",:">")
+	if del="" set tp=2,del=">"
 	for i=1:1:$l(tp,",") {
 		if $p(tp,",",i)=1 {	set prompt=prompt_$p($system,":")_del continue}
 		elseif $p(tp,",",i)=2 {	set prompt=prompt_$namespace_del continue}

--- a/src/cls/_ZPM/PackageManager/Client/Settings.cls
+++ b/src/cls/_ZPM/PackageManager/Client/Settings.cls
@@ -14,9 +14,13 @@ Parameter trackingId = "analytics_tracking_id";
 
 Parameter analytics = "analytics_available";
 
+/// Possible values: dark, white, none
 Parameter ColorScheme = "ColorScheme";
 
-Parameter CONFIGURABLE = "trackingId,analytics,ColorScheme";
+/// Possible values: green, red, violet, blue, yellow, none
+Parameter TerminalPrompt = "TerminalPrompt";
+
+Parameter CONFIGURABLE = "trackingId,analytics,ColorScheme,TerminalPrompt";
 
 /// Returns configArray, that includes all configurable settings
 ClassMethod GetAll(Output configArray) As %Status

--- a/src/inc/_ZPM/PackageManager/Common.inc
+++ b/src/inc/_ZPM/PackageManager/Common.inc
@@ -25,6 +25,7 @@ ROUTINE %ZPM.PackageManager.Common [Type=INC]
 #define escBg $Case(##class(%ZPM.PackageManager.Client.Settings).GetValue("ColorScheme"),"white":47,"dark":40,:0)
 #define escGreen(%t) $Select($$$escBg=0:%t,1:$c(27)_"[1;32;"_$$$escBg_"m"_%t_$$$escClear)
 #define escBlue(%t) $Select($$$escBg=0:%t,1:$c(27)_"[1;36;"_$$$escBg_"m"_%t_$$$escClear)
+#define escRed(%t) $Select($$$escBg=0:%t,1:$c(27)_"[1;31;"_$$$escBg_"m"_%t_$$$escClear)
 #define escDefault(%t) $Select($$$escBg=0:%t,1:$c(27)_"[1;3"_$Select($$$escBg=47:0,1:7)_";"_$$$escBg_"m"_%t_$$$escClear)
 #define escYellow(%t) $Select($$$escBg=0:%t,1:$c(27)_"[1;33;"_$$$escBg_"m"_%t_$$$escClear)
 #define escViolet(%t) $Select($$$escBg=0:%t,1:$c(27)_"[1;35;"_$$$escBg_"m"_%t_$$$escClear)


### PR DESCRIPTION
added TerminalPrompt parameter to configuration ZPM. It can take values of different colors, which will be used to color the command prompt. If the value is "none", there will be the old behavior, without using the system parameter TerminalPrompt.

hp-msw:IRIS:USER>
 
hp-msw:IRIS:USER>zpm
zpm:USER>config list
ColorScheme: none
TerminalPrompt: none
analytics: 1
trackingId: UA-126752118-1
 
zpm:USER>config set ColorScheme white
Key "ColorScheme" succesfully updated
 
zpm:USER>config set TerminalPrompt red
Key "TerminalPrompt" succesfully updated
 
zpm:hp-msw>IRIS>USER>ver
 
%SYS> zpm 0.2.11
 Locally installed zpm-registry not found
https://pm.community.intersystems.com - 0.0.2
zpm:hp-msw>IRIS>USER>

task completed
https://github.com/intersystems-community/zpm/issues/154