### PR TITLE
ignore inaccessible namespace in Version()

### DIFF
--- a/src/cls/_ZPM/PackageManager.cls
+++ b/src/cls/_ZPM/PackageManager.cls
@@ -658,12 +658,16 @@ ClassMethod Version(ByRef pCommandInfo) [ Internal ]
 	Set ns=""
 	For { Set ns=$Order(namespace(ns)) Quit:ns=""
 		Kill list
-		Set $namespace=ns
-		Do ..GetListModules("zpm",.list)
-		If $Data(list("zpm-registry")) {
-			Write !,$$$escDefault(ns)_"> "_$$$escGreen("zpm-registry ")_$ListGet(list("zpm-registry"),1)
-			Set Found=ns
-			Do ..GetDefaultCommandRegistry()
+		try {
+			Set $namespace=ns
+			Do ..GetListModules("zpm",.list)
+			If $Data(list("zpm-registry")) {
+				Write !,$$$escDefault(ns)_"> "_$$$escGreen("zpm-registry ")_$ListGet(list("zpm-registry"),1)
+				Set Found=ns
+				Do ..GetDefaultCommandRegistry()
+			}
+		} catch {
+			// just ignore inaccessible namespaces
 		}
 	}
 	Set $namespace="%SYS"


### PR DESCRIPTION
I saw a <DIRECTORY> error when running the "version" command on an instance that had a few older and inaccessible namespaces:

```ObjectScript
USER>zpm
zpm: USER>ver
 
%SYS> zpm 0.2.8
<DIRECTORY> 237 zVersion+11^%ZPM.PackageManager.1 c:\data\inaccessible\
zpm: USER>
```

this minuscule fix just ignores such errors, as I think they are inappropriate when not trying to reach the inaccessible namespace explicitly, as you would through other commands that change namespaces.