### PR TITLE
Fixed issue with uppercased FileCopy resource

### DIFF
--- a/src/cls/_ZPM/PackageManager/Developer/ResourceReference.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/ResourceReference.cls
@@ -429,10 +429,12 @@ Method %OnBeforeSave(insert As %Boolean) As %Status [ Private, ServerOnly = 1 ]
 		Set ..OverrideName = ..OverrideNameGet()
 		
 		// Normalize resource extension for server resources - should always be upper case.
-		If ($Extract(..Name) '= "/") {
-			Set tExt = $Piece(..Name,".",*)
-			Set ..Name = $Piece(..Name,".",1,*-1)_"."_$ZConvert($Piece(..Name,".",*),"U")
-		}
+    If (..ProcessorClass '= "FileCopy") { 
+      If ($Extract(..Name) '= "/") {
+        Set tExt = $Piece(..Name,".",*)
+        Set ..Name = $Piece(..Name,".",1,*-1)_"."_$ZConvert($Piece(..Name,".",*),"U")
+      }
+    }
 		
 		// See if resource already exists as part of a different module.
 		If ..NonNullResourceNameExists(..UniqueName,.tExistingID) && (tExistingID '= ..%Id()) {


### PR DESCRIPTION
this issue was originally discovered by Discord
with module.xml 
```XML
<Parameter Name="folder" Value="irisapp"/>
<FileCopy Name="data" Target="${libdir}/${folder}/data/"/>
```
The log was like this, data unexpectedly in uppercase
```
Copying /usr/irissys/lib/irisapp/data/ to usr/irissys/mgr/Temp/dirbvpfGU/iris-analytics-0.2.6/.DATA/ as directory
```