### PR TITLE
XSLT - don't overwrite CSPApplication Name with Url if both are specified

### DIFF
--- a/src/cls/_ZPM/PackageManager/Developer/Document/Module.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/Document/Module.cls
@@ -487,7 +487,7 @@ XData InternalXSL
       <xsl:with-param name="name" select="'SourcePath'" />
     </xsl:call-template>
   </xsl:template>
-  <xsl:template match="Module/*[@Url and not(@SourcePath) and not(@Path)] ">
+  <xsl:template match="Module/*[@Url and not(@SourcePath) and not(@Path) and not(@Name)]">
     <xsl:call-template name="resource">
       <xsl:with-param name="name" select="'Url'" />
     </xsl:call-template>


### PR DESCRIPTION
Use case: resource name is folder relative to package root, Url is a namespace-dependent CSP application path, e.g.:
```
<CSPApplication Directory="${cspdir}${namespace}/monlbl-viewer" DispatchClass="AppS.NgBuild.Handler" Generated="true" MatchRoles=":%All" Name="/CSP/monlbl-viewer/dist/monlbl-viewer" ProcessorClass="CSPApplication" Recurse="1" ServeFiles="1" ServeFilesTimeout="0" Url="/csp/${namespace}/monlbl-viewer"/>
```
Which should translate to/from:
```
        <Resource Name="/CSP/monlbl-viewer/dist/monlbl-viewer" ProcessorClass="CSPApplication" Generated="true">
          <Attribute Name="DispatchClass">AppS.NgBuild.Handler</Attribute>
          <Attribute Name="Directory">${cspdir}${namespace}/monlbl-viewer</Attribute>
          <Attribute Name="Url">/csp/${namespace}/monlbl-viewer</Attribute>
          <Attribute Name="ServeFiles">1</Attribute>
          <Attribute Name="Recurse">1</Attribute>
          <Attribute Name="ServeFilesTimeout">0</Attribute>
          <Attribute Name="MatchRoles">:%All</Attribute>
        </Resource>
```