### PR TITLE
Fixes issues found in Virtual Summit presentation process

### DIFF
--- a/src/cls/_ZPM/PackageManager/Developer/Utils.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/Utils.cls
@@ -309,7 +309,11 @@ ClassMethod LoadModuleReference(pServerName As %String, pModuleName As %String, 
 			Set tAsArchive = -1
 			Set tPayload = tClient.GetModule(tModRef, .tAsArchive)
 			If (tVerbose) {
-				Write !,"Module "_pModuleName_" was downloaded from " _ pServerName _ " " _ tClient.Location
+				Set serverDef = ##class(%ZPM.PackageManager.Client.ServerDefinition).ServerDefinitionKeyOpen(pServerName)
+				Write !,"Module "_pModuleName_" was downloaded from " _ pServerName
+				If $IsObject(serverDef) {
+					Write " (",serverDef.Details,")"
+				}
 			}
 			Set tFileName = ""
 			If ($ISOBJECT(tPayload)) && (tPayload.%IsA("%Stream.FileBinary") ) {

--- a/src/cls/_ZPM/PackageManager/Server/PublishService.cls
+++ b/src/cls/_ZPM/PackageManager/Server/PublishService.cls
@@ -12,11 +12,8 @@ Parameter USECLASSNAMESPACES = 1;
 
 Method PublishModule(pModule As %ZPM.PackageManager.Core.Module) As %Boolean [ WebMethod ]
 {
-	If (pModule.Version.Build = "snapshot") {
-		// Allow update of snapshot versions with the same full version string.
-		Set tModule = ##class(%ZPM.PackageManager.Server.Module).NameVersionOpen(pModule.Name,pModule.VersionString)
-	}
-	If '$IsObject($Get(tModule)) {
+	Set tModule = ##class(%ZPM.PackageManager.Server.Module).NameVersionOpen(pModule.Name,pModule.VersionString)
+	If '$IsObject(tModule) {
 		Set tModule = ##class(%ZPM.PackageManager.Server.Module).%New()
 	}
 	Set tModule.Name = pModule.Name
@@ -30,11 +27,8 @@ Method PublishModule(pModule As %ZPM.PackageManager.Core.Module) As %Boolean [ W
 
 Method PublishApplication(pApplication As %ZPM.PackageManager.Core.Application) As %Boolean [ WebMethod ]
 {
-	If (pApplication.Version.Build = "snapshot") {
-		// Allow update of snapshot versions with the same full version string.
-		Set tApplication = ##class(%ZPM.PackageManager.Server.Application).NameVersionOpen(pApplication.Name,pApplication.VersionString)
-	}
-	If '$IsObject($Get(tApplication)) {
+	Set tApplication = ##class(%ZPM.PackageManager.Server.Application).NameVersionOpen(pApplication.Name,pApplication.VersionString)
+	If '$IsObject(tApplication) {
 		Set tApplication = ##class(%ZPM.PackageManager.Server.Application).%New()
 	}
 	Set tApplication.Name = pApplication.Name


### PR DESCRIPTION
Re-publishing an artifact to zpm-registry would fail because it couldn't be re-published to the local cache. This is valid in some use cases and should be allowed (specifically if changing underlying dependencies such as zpm version impacts the artifact that is produced).

Also fixed an issue installing from local cache with the -verbose flag.