### PR TITLE
Add ability to specify a post-installation message

### DIFF
--- a/src/cls/_ZPM/PackageManager/Developer/Module.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/Module.cls
@@ -72,6 +72,8 @@ Property DeveloperMode As %Boolean(ForceCodeGenerate = 0, XMLPROJECTION = "NONE"
 /// Default settings - there may be serveral types of these (subclasses of ModuleSetting).
 Property Defaults As list Of %ZPM.PackageManager.Developer.ModuleSetting(CLASSNAME = 1, STORAGEDEFAULT = "array", XMLNAME = "Defaults", XMLPROJECTION = "WRAPPED", XMLREFERENCE = "COMPLETE", XMLTYPECONSTRAINT = "SUBSTITUTIONGROUP");
 
+Property AfterInstallMessage As %String(MAXLEN = "", XMLPROJECTION = "Element");
+
 Method NameSet(val As %RawString) As %Status
 {
 	Set i%Name = $$$lcase(val)
@@ -96,6 +98,13 @@ ClassMethod CheckSystemRequirements(pModuleName As %String) As %Status
 		Set tSC = ex.AsStatus()
 	}
 	Return tSC
+}
+
+Method WriteAfterInstallMessage()
+{
+	If ..AfterInstallMessage '= "" {
+		Write !,..%Evaluate(..AfterInstallMessage),!
+	}
 }
 
 /// Calls <method>%CompareTo</method> on this object and also calls it on any relationships in the class
@@ -1383,6 +1392,7 @@ Method %Evaluate(pAttrValue, ByRef pParams) As %String [ Internal ]
 	Set tCSPDir = ##class(%File).NormalizeDirectory("csp", tInstallDir)
   Set tLibDir = ##class(%File).NormalizeDirectory("lib", tInstallDir)
   Set tVerbose = +$Get(pParams("Verbose"))
+  Do ##class(%Studio.General).GetWebServerPort(,,,.urlRoot)
 
 	Set tAttrValue = ..%RegExReplace(tAttrValue, "namespace", $Namespace)
 	Set tAttrValue = ..%RegExReplace(tAttrValue, "ns",        $Namespace)
@@ -1392,6 +1402,7 @@ Method %Evaluate(pAttrValue, ByRef pParams) As %String [ Internal ]
 	Set tAttrValue = ..%RegExReplace(tAttrValue, "bindir",    tBinDir)
 	Set tAttrValue = ..%RegExReplace(tAttrValue, "libdir",    tLibDir)
 	Set tAttrValue = ..%RegExReplace(tAttrValue, "verbose",   tVerbose)
+	Set tAttrValue = ..%RegExReplace(tAttrValue, "webroot",   urlRoot)
 
   Set regex = ##class(%Regex.Matcher).%New("#\{([^}]+)\}", tAttrValue)
   While regex.Locate() {
@@ -1486,6 +1497,9 @@ Storage Default
 <Value name="20">
 <Value>DeveloperMode</Value>
 </Value>
+<Value name="21">
+<Value>AfterInstallMessage</Value>
+</Value>
 </Data>
 <DataLocation>^ZPM.Dev.ModuleD</DataLocation>
 <DefaultData>ModuleDefaultData</DefaultData>
@@ -1496,3 +1510,4 @@ Storage Default
 }
 
 }
+

--- a/src/cls/_ZPM/PackageManager/Developer/Utils.cls
+++ b/src/cls/_ZPM/PackageManager/Developer/Utils.cls
@@ -1051,6 +1051,7 @@ ClassMethod LoadNewModule(pDirectory As %String, ByRef pParams, pRepository As %
 			TCOMMIT
 		}
 		$$$ThrowOnError(tSC)
+		Do tModule.WriteAfterInstallMessage()
 	} Catch e {
 		Set tSC = e.AsStatus()
 	}
@@ -1798,3 +1799,4 @@ ClassMethod GetFileLines(pFileName As %String, Output pOutput) As %Status [ Inte
 }
 
 }
+


### PR DESCRIPTION
Fixes #236 - I'd just been thinking that I wanted this and happened across the issue @evshvarov filed about it.

Example from one of my side projects:
<AfterInstallMessage>You can view the Line-by-Line Monitor UI at: ${webroot}csp/${namespace}/monlbl-viewer/</AfterInstallMessage>
Prints e.g.:
ZPM>zpm "install monlbl-viewer"

[monlbl-viewer] Reload START (C:\InterSystems\IRIS20\Mgr\.modules\ZPM\monlbl-viewer\1.0.0\)
[monlbl-viewer] Reload SUCCESS
[monlbl-viewer] Module object refreshed.
[monlbl-viewer] Validate START
[monlbl-viewer] Validate SUCCESS
[monlbl-viewer] Compile START
[monlbl-viewer] Compile SUCCESS
[monlbl-viewer] Activate START
[monlbl-viewer] Configure START
[monlbl-viewer] Configure SUCCESS
[monlbl-viewer] MakeDeployed START
[monlbl-viewer] MakeDeployed SUCCESS
[monlbl-viewer] Activate SUCCESS
You can view the Line-by-Line Monitor UI at: http://172.16.8.46:52775/csp/ZPM/monlbl-viewer/