### PR TITLE
Return HTTP status on publish error

### DIFF
--- a/src/cls/_ZPM/PackageManager/Client/REST/PublishClient.cls
+++ b/src/cls/_ZPM/PackageManager/Client/REST/PublishClient.cls
@@ -29,7 +29,8 @@ Method Publish(pModule As %ZPM.PackageManager.Core.VersionedBase) As %Boolean
     If tRequest.HttpResponse.StatusCode = 401 {
       $$$ThrowStatus($$$ERROR($$$GeneralError, "Publishing module, authorization required."))
     } Else {
-      $$$ThrowStatus($$$ERROR($$$GeneralError, "Publishing module, something went wrong."))
+	    set tMessage = "Publishing module, server responded with status code "_tRequest.HttpResponse.StatusCode_"."
+      $$$ThrowStatus($$$ERROR($$$GeneralError, tMessage))
     }
   }
   Quit 1

--- a/src/cls/_ZPM/PackageManager/Client/REST/PublishClient.cls
+++ b/src/cls/_ZPM/PackageManager/Client/REST/PublishClient.cls
@@ -29,7 +29,7 @@ Method Publish(pModule As %ZPM.PackageManager.Core.VersionedBase) As %Boolean
     If tRequest.HttpResponse.StatusCode = 401 {
       $$$ThrowStatus($$$ERROR($$$GeneralError, "Publishing module, authorization required."))
     } Else {
-	    set tMessage = "Publishing module, server responded with status code "_tRequest.HttpResponse.StatusCode_"."
+      set tMessage = "Publishing module, server responded with status code "_tRequest.HttpResponse.StatusCode_"."
       $$$ThrowStatus($$$ERROR($$$GeneralError, tMessage))
     }
   }


### PR DESCRIPTION
Hey!

While working with our own zpm registry for internal packages, I had an error "Publishing module, something went wrong." without any clue what was going on. Turns out our nginx throws a HTTP 413. 

This change tells the user the HTTP status code of the publish request in case of an error. It's just a minor thing, but maybe it helps people in the future!